### PR TITLE
fix(security): FORGE-631 harden password reset against traversal and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,43 +32,35 @@ and therefore ignored by Git.
      </dependency>
 ```
  
-add mail session JNDI resource to local context.xml, e.g.:
- 
-```
-    <Resource name="mail/Session" 
-      auth="Container" 
-      type="javax.mail.Session" 
-      mail.smtp.host="127.0.0.1"
-      mail.smtp.port= "2525"  
-      />
-```
+The demo `context.xml` is pre-configured to use `localhost:2525`. Start a local SMTP trap before running the demo:
 
-___
-Download  FakeSMTP from:
-
-[https://github.com/Nilhcem/FakeSMTP](https://github.com/Nilhcem/FakeSMTP)
-
-and run it as:
+**Mailpit** (recommended — web UI at `http://localhost:8025`):
 
 ```bash
-java -jar fakeSMTP-2.1-SNAPSHOT.jar -s  -p 2525 -a 127.0.0.1
+brew install mailpit
+mailpit --smtp 0.0.0.0:2525
 ```
-If you encounter issues on Mac, you can try to run it as:
+
+**Docker (no install):**
 
 ```bash
-java --add-exports java.desktop/com.apple.eawt=ALL-UNNAMED -jar fakeSMTP-2.1-SNAPSHOT.jar -s -p 2525 -a 127.0.0.1
+docker run --rm -p 2525:25 -p 8025:8025 axllent/mailpit
 ```
 
-You may also need to update FakeSMTP to use Java 7 instead of Java 6.
-___
--> Go to CMS login page.
+If you need to point a different project at a local mail session, add this JNDI resource to its `context.xml`:
 
--> Click on Forgot password, it will take you to the Reset Password page.
+```xml
+<Resource name="mail/Session"
+  auth="Container"
+  type="jakarta.mail.Session"
+  mail.smtp.host="127.0.0.1"
+  mail.smtp.port="2525"/>
+```
 
--> Enter the username and click on Reset.
+---
 
--> An email will be sent to the Fake SMTP Server with a link to reset the password.
-
--> Click on the link, it will take you to the Reset Password page, enter the new password and click on Reset.
-
--> Go to the CMS Login page and test the new password.
+1. Go to the CMS login page and click **Forgot password**.
+2. Enter a username and click **Reset** — the email will be captured by Mailpit.
+3. Open `http://localhost:8025`, find the email, and click the reset link.
+4. Enter and confirm the new password, then click **Reset**.
+5. Return to the CMS login page and verify the new password works.

--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -13,6 +13,18 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.8.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.onehippo.cms7</groupId>
       <artifactId>hippo-cms-login</artifactId>
       <scope>provided</scope>

--- a/cms/src/main/java/org/onehippo/forge/resetpassword/frontend/ResetPasswordPanel.java
+++ b/cms/src/main/java/org/onehippo/forge/resetpassword/frontend/ResetPasswordPanel.java
@@ -16,10 +16,13 @@
 package org.onehippo.forge.resetpassword.frontend;
 
 import java.text.SimpleDateFormat;
+import java.time.Duration;
 import java.util.Calendar;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.jcr.Node;
 import javax.jcr.PathNotFoundException;
@@ -53,6 +56,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.http.HttpServletRequest;
+
 import static org.onehippo.forge.resetpassword.frontend.ResetPasswordConst.HIPPO_USERS_PATH;
 import static org.onehippo.forge.resetpassword.frontend.ResetPasswordConst.PASSWORD_RESET_KEY;
 import static org.onehippo.forge.resetpassword.frontend.ResetPasswordConst.PASSWORD_RESET_TIMESTAMP;
@@ -60,19 +64,18 @@ import static org.onehippo.forge.resetpassword.frontend.ResetPasswordConst.PASSW
 /**
  * ResetPasswordPanel
  * Panel on ResetPasswordFrame, showing only a field for entering the username
- * <p>
- * Based on SimpleLoginPlugin and LoginPlugin.
  */
 public class ResetPasswordPanel extends Panel {
 
     private static final Logger log = LoggerFactory.getLogger(ResetPasswordPanel.class);
 
     private static final String DATE_FORMAT = "dd-MM-yyyy HH:mm";
-    private static final String SPACE = " ";
 
     private static final Pattern EMAIL_PARAM_NAME_PATTERN = Pattern.compile("\\$\\{name\\}");
     private static final Pattern EMAIL_PARAM_URL_PATTERN = Pattern.compile("\\$\\{url\\}");
     private static final Pattern EMAIL_PARAM_VALIDITY_PATTERN = Pattern.compile("\\$\\{validity\\}");
+
+    static final ResetPasswordRateLimiter RATE_LIMITER = new ResetPasswordRateLimiter(Duration.ofMinutes(1));
 
     /**
      * Constructor
@@ -84,6 +87,16 @@ public class ResetPasswordPanel extends Panel {
 
         add(ClassAttribute.append("login-panel-center"));
         add(new ResetPasswordForm(panelInfo.isAutoComplete(), panelInfo.getUserId(), panelInfo.getConfiguration()));
+    }
+
+    /**
+     * Builds a display name from optional first and last name parts.
+     * Returns only the non-blank parts joined by a space; empty string if both are blank.
+     */
+    static String buildUserDisplayName(final String firstName, final String lastName) {
+        return Stream.of(firstName, lastName)
+                .filter(StringUtils::isNotBlank)
+                .collect(Collectors.joining(" "));
     }
 
     /**
@@ -129,7 +142,6 @@ public class ResetPasswordPanel extends Panel {
 
             feedback = new FeedbackPanel("feedback");
             feedback.setOutputMarkupId(true);
-            feedback.setEscapeModelStrings(false);
             add(feedback);
         }
 
@@ -139,6 +151,16 @@ public class ResetPasswordPanel extends Panel {
         @Override
         public final void onSubmit() {
 
+            if (!UserIdValidator.isValid(userId)) {
+                info(labelMap.get(Configuration.INFORMATION_INCOMPLETE));
+                return;
+            }
+
+            if (!RATE_LIMITER.isAllowed(userId)) {
+                info(labelMap.get(Configuration.INFORMATION_INCOMPLETE));
+                return;
+            }
+
             boolean resetSuccess = false;
             try {
                 final PluginUserSession userSession = PluginUserSession.get();
@@ -146,9 +168,10 @@ public class ResetPasswordPanel extends Panel {
 
                 if (resetPassword(jcrSession)) {
                     resetSuccess = true;
+                    RATE_LIMITER.recordAttempt(userId);
                 }
             } catch (final PathNotFoundException ignore) {
-                log.info("Unknown username: {}", userId);
+                log.info("Unknown username during reset request");
                 info(labelMap.get(Configuration.INFORMATION_INCOMPLETE));
             } catch (final EmailException e) {
                 log.error("Sending mail failed.", e);
@@ -159,7 +182,6 @@ public class ResetPasswordPanel extends Panel {
             }
 
             if (resetSuccess) {
-                // show success stuff
                 resetPasswordFormTable.setVisible(false);
                 info(labelMap.get(Configuration.EMAIL_SENT));
             }
@@ -176,27 +198,25 @@ public class ResetPasswordPanel extends Panel {
 
         private boolean resetPassword(final Session session) throws RepositoryException, EmailException {
 
-            final Node userNode;
-            userNode = session.getNode(HIPPO_USERS_PATH + userId);
+            final Node userNode = session.getNode(HIPPO_USERS_PATH + userId);
 
-            // check if user is active
             boolean hippoUserActive = true;
             if (userNode.hasProperty("hipposys:active")) {
                 hippoUserActive = userNode.getProperty("hipposys:active").getBoolean();
             }
             if (!hippoUserActive) {
-                log.error("User is not active: {}", userId);
+                log.error("User is not active");
                 error(labelMap.get(Configuration.INFORMATION_INCOMPLETE));
                 return false;
             }
-            
+
             String hippoUserEmail = null;
             if (userNode.hasProperty("hipposys:email")) {
                 hippoUserEmail = userNode.getProperty("hipposys:email").getString();
             }
 
             if (StringUtils.isEmpty(hippoUserEmail)) {
-                log.error("Unknown e-mail: {}", userId);
+                log.error("No e-mail configured for user");
                 error(labelMap.get(Configuration.INFORMATION_INCOMPLETE));
                 return false;
             }
@@ -210,18 +230,17 @@ public class ResetPasswordPanel extends Panel {
 
             final String mailText = getMailText(url, userName, expiryDate);
 
-            sendEmail(hippoUserEmail, userName, mailText);
-            log.debug("Sending mail link to user: {}", mailText);
-            // persist code and exp.date
-            // Node should be relaxed before adding extra properties
+            // Persist the token before sending the email so the link is always valid
+            // if delivered, even if a previous send attempt failed.
             if (userNode.canAddMixin("hippostd:relaxed")) {
                 userNode.addMixin("hippostd:relaxed");
             }
             final Calendar currentDate = (Calendar) dateNow.clone();
             userNode.setProperty(PASSWORD_RESET_TIMESTAMP, currentDate);
             userNode.setProperty(PASSWORD_RESET_KEY, code);
-
             session.save();
+
+            sendEmail(hippoUserEmail, userName, mailText);
 
             return true;
         }
@@ -233,7 +252,6 @@ public class ResetPasswordPanel extends Panel {
         }
 
         private String getMailText(final String url, final String username, final Calendar expireDate) {
-            // generate text
             String mailText = labelMap.get(Configuration.EMAIL_TEXT_RESET);
 
             mailText = EMAIL_PARAM_NAME_PATTERN.matcher(mailText).replaceAll(username);
@@ -265,15 +283,15 @@ public class ResetPasswordPanel extends Panel {
         }
 
         private String getUserName(final Node userNode) throws RepositoryException {
-            String hippoUserFirstName = null;
+            String firstName = null;
             if (userNode.hasProperty("hipposys:firstname")) {
-                hippoUserFirstName = userNode.getProperty("hipposys:firstname").getString();
+                firstName = userNode.getProperty("hipposys:firstname").getString();
             }
-            String hippoUserLastName = null;
+            String lastName = null;
             if (userNode.hasProperty("hipposys:lastname")) {
-                hippoUserLastName = userNode.getProperty("hipposys:lastname").getString();
+                lastName = userNode.getProperty("hipposys:lastname").getString();
             }
-            return hippoUserFirstName + SPACE + hippoUserLastName;
+            return buildUserDisplayName(firstName, lastName);
         }
 
         private void addLabelledComponent(final WebMarkupContainer container, final Component component) {

--- a/cms/src/main/java/org/onehippo/forge/resetpassword/frontend/ResetPasswordRateLimiter.java
+++ b/cms/src/main/java/org/onehippo/forge/resetpassword/frontend/ResetPasswordRateLimiter.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2024 Bloomreach Inc. (https://www.bloomreach.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.onehippo.forge.resetpassword.frontend;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * Per-username rate limiter for password reset requests.
+ * State is in-memory and does not survive restarts, which is intentional:
+ * the goal is to slow down automated abuse, not provide a hard guarantee.
+ */
+class ResetPasswordRateLimiter {
+
+    private final Map<String, Instant> lastAttempt = new ConcurrentHashMap<>();
+    private final Duration cooldown;
+    private final Supplier<Instant> clock;
+
+    ResetPasswordRateLimiter(final Duration cooldown) {
+        this(cooldown, Instant::now);
+    }
+
+    ResetPasswordRateLimiter(final Duration cooldown, final Supplier<Instant> clock) {
+        this.cooldown = cooldown;
+        this.clock = clock;
+    }
+
+    boolean isAllowed(final String userId) {
+        final Instant last = lastAttempt.get(userId);
+        if (last == null) {
+            return true;
+        }
+        return clock.get().isAfter(last.plus(cooldown));
+    }
+
+    void recordAttempt(final String userId) {
+        lastAttempt.put(userId, clock.get());
+    }
+}

--- a/cms/src/main/java/org/onehippo/forge/resetpassword/frontend/SetPasswordPanel.java
+++ b/cms/src/main/java/org/onehippo/forge/resetpassword/frontend/SetPasswordPanel.java
@@ -15,6 +15,7 @@
  */
 package org.onehippo.forge.resetpassword.frontend;
 
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
@@ -64,8 +65,6 @@ import static org.onehippo.forge.resetpassword.frontend.ResetPasswordConst.PASSW
 /**
  * SetPasswordPanel
  * Panel on ResetPasswordFrame, showing two fields for entering the new password twice
- * <p>
- * Based on @Link{SimpleLoginPlugin} en @Link{LoginPlugin}.
  */
 public class SetPasswordPanel extends Panel {
 
@@ -94,7 +93,6 @@ public class SetPasswordPanel extends Panel {
         String passwordValidationLocation = panelInfo.getConfig().get(PASSWORDVALIDATION_LOCATION).toString();
         JcrPluginConfig pluginConfig = new JcrPluginConfig(new JcrNodeModel(passwordValidationLocation));
         passwordValidationService = new PasswordValidationServiceImpl(panelInfo.getContext(), pluginConfig);
-
     }
 
     @Override
@@ -103,6 +101,50 @@ public class SetPasswordPanel extends Panel {
         response.render(OnDomReadyHeaderItem.forScript("$('#password-verification').bind(\"cut copy paste\",function(e) {" +
                 "  e.preventDefault();" +
                 "});"));
+    }
+
+    /**
+     * Returns true if the submitted code matches the persisted code on the user node.
+     */
+    static boolean isCodeMatch(final String submittedCode, final String persistedCode) {
+        return submittedCode.equals(persistedCode);
+    }
+
+    /**
+     * Returns true if the link has expired (current time is strictly after timestamp + urlValidityMinutes).
+     */
+    static boolean isLinkExpired(final Calendar persistedTimestamp, final int urlValidityMinutes, final Instant now) {
+        final Calendar expiry = (Calendar) persistedTimestamp.clone();
+        expiry.add(Calendar.MINUTE, urlValidityMinutes);
+        return now.toEpochMilli() > expiry.getTimeInMillis();
+    }
+
+    /**
+     * Validates the reset code on the user node; throws if missing or mismatched.
+     */
+    static void validateCode(final String code, final String uid, final Node userNode)
+            throws RepositoryException, ResetPasswordException {
+        if (!userNode.hasProperty(PASSWORD_RESET_KEY)) {
+            throw new ResetPasswordException("No reset key property on node: " + uid);
+        }
+        final String persistedCode = userNode.getProperty(PASSWORD_RESET_KEY).getString();
+        if (!isCodeMatch(code, persistedCode)) {
+            throw new ResetPasswordException("Verification code mismatch for: " + uid);
+        }
+    }
+
+    /**
+     * Validates the reset timestamp on the user node; throws if missing or expired.
+     */
+    static void validateTimestamp(final String uid, final Node userNode, final int urlValidityMinutes)
+            throws RepositoryException, ResetPasswordException, ResetPasswordLinkExpiredException {
+        if (!userNode.hasProperty(PASSWORD_RESET_TIMESTAMP)) {
+            throw new ResetPasswordException("No reset timestamp property on node: " + uid);
+        }
+        final Calendar persistedTimestamp = userNode.getProperty(PASSWORD_RESET_TIMESTAMP).getDate();
+        if (isLinkExpired(persistedTimestamp, urlValidityMinutes, Instant.now())) {
+            throw new ResetPasswordLinkExpiredException("The link has expired");
+        }
     }
 
     protected class SetPasswordForm extends Form<Void> {
@@ -132,7 +174,6 @@ public class SetPasswordPanel extends Panel {
 
             feedback = new FeedbackPanel("feedback");
             feedback.setOutputMarkupId(true);
-            feedback.setEscapeModelStrings(false);
             add(feedback);
 
             loginLink = new WebMarkupContainer("loginLink");
@@ -154,8 +195,8 @@ public class SetPasswordPanel extends Panel {
 
             final boolean hasParameters = StringUtils.isNotEmpty(code) && StringUtils.isNotEmpty(uid);
             if (hasParameters) {
-                final boolean validParameters = validateForm(code, uid);
-                if (!validParameters) {
+                final boolean isValid = validateForm(code, uid);
+                if (!isValid) {
                     setPasswordFormTable.setVisible(false);
                     resetLink.setVisible(true);
                 }
@@ -187,12 +228,10 @@ public class SetPasswordPanel extends Panel {
             }
 
             try {
-                final PluginUserSession userSession = PluginUserSession.get();
-                final Session jcrSession = userSession.getJcrSession();
+                final Session jcrSession = PluginUserSession.get().getJcrSession();
 
                 validateUid(code, uid, jcrSession);
 
-                // validate password
                 final User user = new User(uid);
 
                 final List<PasswordValidationStatus> statuses =
@@ -215,30 +254,24 @@ public class SetPasswordPanel extends Panel {
             try {
                 final Session jcrSession = PluginUserSession.get().getJcrSession();
 
-                final User user = new User(uid);
-                user.savePassword(password);
-                info(labelMap.get(Configuration.PASSWORD_RESET_DONE));
-
-                setPasswordFormTable.setVisible(false);
-                loginLink.setVisible(true);
-
                 final Node userNode = jcrSession.getNode(HIPPO_USERS_PATH + uid);
-                if (userNode == null) {
-                    log.info("Unknown username: {}", uid);
-                    error(labelMap.get(Configuration.INFORMATION_INCOMPLETE));
-                    return;
-                }
 
+                // Remove the reset token before saving the new password so a
+                // failed savePassword call cannot be retried with the same link.
                 if (userNode.hasProperty(PASSWORD_RESET_TIMESTAMP)) {
                     userNode.getProperty(PASSWORD_RESET_TIMESTAMP).remove();
                 }
-
                 if (userNode.hasProperty(PASSWORD_RESET_KEY)) {
                     userNode.getProperty(PASSWORD_RESET_KEY).remove();
                 }
-
-                // persist code and exp.date
                 jcrSession.save();
+
+                final User user = new User(uid);
+                user.savePassword(password);
+
+                info(labelMap.get(Configuration.PASSWORD_RESET_DONE));
+                setPasswordFormTable.setVisible(false);
+                loginLink.setVisible(true);
 
             } catch (final RepositoryException re) {
                 log.error("Error saving password SetPasswordForm", re);
@@ -246,71 +279,49 @@ public class SetPasswordPanel extends Panel {
             }
         }
 
+        /**
+         * Returns true if the code+uid parameters are valid (form should be shown).
+         * Returns false if invalid (form should be hidden, reset link shown).
+         */
         private boolean validateForm(final String code, final String uid) {
-
             try {
                 final Session jcrSession = PluginUserSession.get().getJcrSession();
-
-                if (validateUid(code, uid, jcrSession)) {
-                    return false;
-                }
+                return validateUid(code, uid, jcrSession);
             } catch (final RepositoryException e) {
                 log.error("Error validating SetPasswordForm", e);
                 error(labelMap.get(Configuration.SYSTEM_ERROR));
                 return false;
             }
-            return true;
         }
 
+        /**
+         * Returns true if the uid and code are valid; false if any check fails (errors added to form).
+         */
         private boolean validateUid(final String code, final String uid, final Session session) throws RepositoryException {
+            if (!UserIdValidator.isValid(uid)) {
+                error(labelMap.get(Configuration.INFORMATION_INCOMPLETE));
+                return false;
+            }
             try {
                 final Node userNode = session.getNode(HIPPO_USERS_PATH + uid);
 
                 validateCode(code, uid, userNode);
-                validateTimestamp(uid, userNode);
+                validateTimestamp(uid, userNode, urlValidity);
+
+                return true;
 
             } catch (final PathNotFoundException pnfe) {
-                log.error("Unknown username: {}", uid, pnfe);
+                log.error("Unknown username during password reset", pnfe);
                 error(labelMap.get(Configuration.INFORMATION_INCOMPLETE));
-                return true;
+                return false;
             } catch (final ResetPasswordException rpe) {
-                log.info("Error handling verification {}, {}", code, uid, rpe);
+                log.info("Invalid reset parameters: {}", rpe.getMessage());
                 error(labelMap.get(Configuration.INFORMATION_INCOMPLETE));
-                return true;
+                return false;
             } catch (final ResetPasswordLinkExpiredException rpplee) {
-                log.info("Error handling verification {}, {}", code, uid, rpplee);
+                log.info("Expired reset link used");
                 error(labelMap.get(Configuration.RESET_LINK_EXPIRED));
-                return true;
-            }
-            return false;
-        }
-
-        private void validateTimestamp(final String uid, final Node userNode) throws RepositoryException, ResetPasswordException, ResetPasswordLinkExpiredException {
-            final Calendar currentTime = Calendar.getInstance();
-
-            final Calendar persistedTimestamp;
-            if (userNode.hasProperty(PASSWORD_RESET_TIMESTAMP)) {
-                persistedTimestamp = userNode.getProperty(PASSWORD_RESET_TIMESTAMP).getDate();
-            } else {
-                throw new ResetPasswordException(
-                        "No " + PASSWORD_RESET_TIMESTAMP + " property found on node: " + uid);
-            }
-            persistedTimestamp.add(Calendar.MINUTE, urlValidity);
-            if (currentTime.after(persistedTimestamp)) {
-                throw new ResetPasswordLinkExpiredException("The link has expired");
-            }
-        }
-
-        private void validateCode(final String code, final String uid, final Node userNode) throws RepositoryException, ResetPasswordException {
-            final String persistedCode;
-            if (userNode.hasProperty(PASSWORD_RESET_KEY)) {
-                persistedCode = userNode.getProperty(PASSWORD_RESET_KEY).getString();
-            } else {
-                throw new ResetPasswordException("No email present on node: " + uid);
-            }
-            if (!code.equals(persistedCode)) {
-                throw new ResetPasswordException(
-                        "Verification code passed in the url does not equal the persisted verification code");
+                return false;
             }
         }
 

--- a/cms/src/main/java/org/onehippo/forge/resetpassword/frontend/UserIdValidator.java
+++ b/cms/src/main/java/org/onehippo/forge/resetpassword/frontend/UserIdValidator.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2024 Bloomreach Inc. (https://www.bloomreach.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.onehippo.forge.resetpassword.frontend;
+
+/**
+ * Validates user IDs before they are used to construct JCR paths.
+ *
+ * The CMS itself imposes no character restriction on usernames beyond a minimum
+ * length of 2. This validator blocks only the characters that enable JCR path
+ * traversal: the path separator '/', the parent-navigation sequence '..', and
+ * null bytes. All other characters — including Unicode and '+' in email-style
+ * names — are left to the JCR layer to accept or reject.
+ */
+public final class UserIdValidator {
+
+    private UserIdValidator() {
+    }
+
+    /**
+     * Returns true if the userId cannot be used for JCR path traversal.
+     * Rejects null, strings shorter than 2 characters, and strings containing
+     * '/', '..', or null bytes.
+     */
+    public static boolean isValid(final String userId) {
+        return userId != null
+                && userId.length() >= 2
+                && !userId.contains("/")
+                && !userId.contains("..")
+                && !userId.contains("\0");
+    }
+}

--- a/cms/src/test/java/org/onehippo/forge/resetpassword/frontend/ResetPasswordPanelTest.java
+++ b/cms/src/test/java/org/onehippo/forge/resetpassword/frontend/ResetPasswordPanelTest.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2024 Bloomreach Inc. (https://www.bloomreach.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.onehippo.forge.resetpassword.frontend;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ResetPasswordPanelTest {
+
+    @Test
+    void buildUserDisplayName_returns_full_name_when_both_present() {
+        assertEquals("John Smith", ResetPasswordPanel.buildUserDisplayName("John", "Smith"));
+    }
+
+    @Test
+    void buildUserDisplayName_returns_first_name_only_when_last_is_null() {
+        assertEquals("John", ResetPasswordPanel.buildUserDisplayName("John", null));
+    }
+
+    @Test
+    void buildUserDisplayName_returns_last_name_only_when_first_is_null() {
+        assertEquals("Smith", ResetPasswordPanel.buildUserDisplayName(null, "Smith"));
+    }
+
+    @Test
+    void buildUserDisplayName_returns_empty_string_when_both_null() {
+        assertEquals("", ResetPasswordPanel.buildUserDisplayName(null, null));
+    }
+
+    @Test
+    void buildUserDisplayName_returns_empty_string_when_both_blank() {
+        assertEquals("", ResetPasswordPanel.buildUserDisplayName("  ", "  "));
+    }
+
+    @Test
+    void buildUserDisplayName_trims_blank_first_name() {
+        assertEquals("Smith", ResetPasswordPanel.buildUserDisplayName("   ", "Smith"));
+    }
+}

--- a/cms/src/test/java/org/onehippo/forge/resetpassword/frontend/ResetPasswordRateLimiterTest.java
+++ b/cms/src/test/java/org/onehippo/forge/resetpassword/frontend/ResetPasswordRateLimiterTest.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright 2024 Bloomreach Inc. (https://www.bloomreach.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.onehippo.forge.resetpassword.frontend;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ResetPasswordRateLimiterTest {
+
+    @Test
+    void first_request_for_any_user_is_allowed() {
+        final var limiter = new ResetPasswordRateLimiter(Duration.ofMinutes(1));
+        assertTrue(limiter.isAllowed("alice"));
+    }
+
+    @Test
+    void request_within_cooldown_window_is_blocked() {
+        final Instant now = Instant.now();
+        final var limiter = new ResetPasswordRateLimiter(Duration.ofMinutes(1), () -> now);
+        limiter.recordAttempt("alice");
+        assertFalse(limiter.isAllowed("alice"));
+    }
+
+    @Test
+    void request_at_exactly_cooldown_boundary_is_blocked() {
+        final AtomicReference<Instant> clock = new AtomicReference<>(Instant.now());
+        final var limiter = new ResetPasswordRateLimiter(Duration.ofMinutes(1), clock::get);
+        limiter.recordAttempt("alice");
+        clock.set(clock.get().plus(Duration.ofMinutes(1)));
+        // isAfter is strict: now == expiry means NOT yet past cooldown
+        assertFalse(limiter.isAllowed("alice"));
+    }
+
+    @Test
+    void request_after_cooldown_is_allowed() {
+        final AtomicReference<Instant> clock = new AtomicReference<>(Instant.now());
+        final var limiter = new ResetPasswordRateLimiter(Duration.ofMinutes(1), clock::get);
+        limiter.recordAttempt("alice");
+        clock.set(clock.get().plus(Duration.ofMinutes(1)).plusSeconds(1));
+        assertTrue(limiter.isAllowed("alice"));
+    }
+
+    @Test
+    void different_users_have_independent_limits() {
+        final Instant now = Instant.now();
+        final var limiter = new ResetPasswordRateLimiter(Duration.ofMinutes(1), () -> now);
+        limiter.recordAttempt("alice");
+        assertTrue(limiter.isAllowed("bob"));
+    }
+
+    @Test
+    void second_attempt_resets_cooldown_timer() {
+        final AtomicReference<Instant> clock = new AtomicReference<>(Instant.now());
+        final var limiter = new ResetPasswordRateLimiter(Duration.ofMinutes(1), clock::get);
+        limiter.recordAttempt("alice");
+        // advance past cooldown so a second attempt is recorded
+        clock.set(clock.get().plus(Duration.ofMinutes(2)));
+        limiter.recordAttempt("alice");
+        // now back within cooldown window of the second attempt
+        clock.set(clock.get().minus(Duration.ofSeconds(30)));
+        assertFalse(limiter.isAllowed("alice"));
+    }
+}

--- a/cms/src/test/java/org/onehippo/forge/resetpassword/frontend/SetPasswordPanelTest.java
+++ b/cms/src/test/java/org/onehippo/forge/resetpassword/frontend/SetPasswordPanelTest.java
@@ -1,0 +1,157 @@
+/*
+ *  Copyright 2024 Bloomreach Inc. (https://www.bloomreach.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.onehippo.forge.resetpassword.frontend;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Calendar;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+import static org.onehippo.forge.resetpassword.frontend.ResetPasswordConst.PASSWORD_RESET_KEY;
+import static org.onehippo.forge.resetpassword.frontend.ResetPasswordConst.PASSWORD_RESET_TIMESTAMP;
+
+class SetPasswordPanelTest {
+
+    // --- isCodeMatch ---
+
+    @Test
+    void isCodeMatch_returns_true_for_identical_codes() {
+        assertTrue(SetPasswordPanel.isCodeMatch("abc-123", "abc-123"));
+    }
+
+    @Test
+    void isCodeMatch_returns_false_for_different_codes() {
+        assertFalse(SetPasswordPanel.isCodeMatch("abc-123", "xyz-456"));
+    }
+
+    @Test
+    void isCodeMatch_is_case_sensitive() {
+        assertFalse(SetPasswordPanel.isCodeMatch("ABC-123", "abc-123"));
+    }
+
+    // --- isLinkExpired ---
+
+    @Test
+    void isLinkExpired_returns_false_when_within_validity_window() {
+        final Instant now = Instant.now();
+        final Calendar timestamp = calendarAt(now.minus(30, ChronoUnit.MINUTES));
+        assertFalse(SetPasswordPanel.isLinkExpired(timestamp, 60, now));
+    }
+
+    @Test
+    void isLinkExpired_returns_true_when_past_validity_window() {
+        final Instant now = Instant.now();
+        final Calendar timestamp = calendarAt(now.minus(90, ChronoUnit.MINUTES));
+        assertTrue(SetPasswordPanel.isLinkExpired(timestamp, 60, now));
+    }
+
+    @Test
+    void isLinkExpired_returns_false_at_exact_expiry_boundary() {
+        final Instant now = Instant.now();
+        // timestamp is exactly urlValidity minutes ago → expiry == now → not after → not expired
+        final Calendar timestamp = calendarAt(now.minus(60, ChronoUnit.MINUTES));
+        assertFalse(SetPasswordPanel.isLinkExpired(timestamp, 60, now));
+    }
+
+    @Test
+    void isLinkExpired_returns_true_one_second_past_expiry() {
+        final Instant now = Instant.now();
+        final Calendar timestamp = calendarAt(now.minus(60, ChronoUnit.MINUTES).minus(1, ChronoUnit.SECONDS));
+        assertTrue(SetPasswordPanel.isLinkExpired(timestamp, 60, now));
+    }
+
+    // --- validateCode (JCR-touching, uses Mockito) ---
+
+    @Test
+    void validateCode_throws_ResetPasswordException_when_key_property_missing() throws Exception {
+        final Node node = Mockito.mock(Node.class);
+        when(node.hasProperty(PASSWORD_RESET_KEY)).thenReturn(false);
+
+        assertThrows(ResetPasswordException.class, () ->
+                SetPasswordPanel.validateCode("any-code", "alice", node));
+    }
+
+    @Test
+    void validateCode_throws_ResetPasswordException_when_codes_differ() throws Exception {
+        final Node node = Mockito.mock(Node.class);
+        final Property prop = Mockito.mock(Property.class);
+        when(node.hasProperty(PASSWORD_RESET_KEY)).thenReturn(true);
+        when(node.getProperty(PASSWORD_RESET_KEY)).thenReturn(prop);
+        when(prop.getString()).thenReturn("stored-code");
+
+        assertThrows(ResetPasswordException.class, () ->
+                SetPasswordPanel.validateCode("different-code", "alice", node));
+    }
+
+    @Test
+    void validateCode_does_not_throw_when_codes_match() throws Exception {
+        final Node node = Mockito.mock(Node.class);
+        final Property prop = Mockito.mock(Property.class);
+        when(node.hasProperty(PASSWORD_RESET_KEY)).thenReturn(true);
+        when(node.getProperty(PASSWORD_RESET_KEY)).thenReturn(prop);
+        when(prop.getString()).thenReturn("correct-code");
+
+        assertDoesNotThrow(() -> SetPasswordPanel.validateCode("correct-code", "alice", node));
+    }
+
+    // --- validateTimestamp (JCR-touching, uses Mockito) ---
+
+    @Test
+    void validateTimestamp_throws_ResetPasswordException_when_timestamp_property_missing() throws Exception {
+        final Node node = Mockito.mock(Node.class);
+        when(node.hasProperty(PASSWORD_RESET_TIMESTAMP)).thenReturn(false);
+
+        assertThrows(ResetPasswordException.class, () ->
+                SetPasswordPanel.validateTimestamp("alice", node, 60));
+    }
+
+    @Test
+    void validateTimestamp_throws_ResetPasswordLinkExpiredException_when_link_expired() throws Exception {
+        final Node node = Mockito.mock(Node.class);
+        final Property prop = Mockito.mock(Property.class);
+        final Calendar oldTimestamp = calendarAt(Instant.now().minus(2, ChronoUnit.HOURS));
+        when(node.hasProperty(PASSWORD_RESET_TIMESTAMP)).thenReturn(true);
+        when(node.getProperty(PASSWORD_RESET_TIMESTAMP)).thenReturn(prop);
+        when(prop.getDate()).thenReturn(oldTimestamp);
+
+        assertThrows(ResetPasswordLinkExpiredException.class, () ->
+                SetPasswordPanel.validateTimestamp("alice", node, 60));
+    }
+
+    @Test
+    void validateTimestamp_does_not_throw_for_fresh_link() throws Exception {
+        final Node node = Mockito.mock(Node.class);
+        final Property prop = Mockito.mock(Property.class);
+        final Calendar recentTimestamp = calendarAt(Instant.now().minus(5, ChronoUnit.MINUTES));
+        when(node.hasProperty(PASSWORD_RESET_TIMESTAMP)).thenReturn(true);
+        when(node.getProperty(PASSWORD_RESET_TIMESTAMP)).thenReturn(prop);
+        when(prop.getDate()).thenReturn(recentTimestamp);
+
+        assertDoesNotThrow(() -> SetPasswordPanel.validateTimestamp("alice", node, 60));
+    }
+
+    private static Calendar calendarAt(final Instant instant) {
+        final Calendar cal = Calendar.getInstance();
+        cal.setTimeInMillis(instant.toEpochMilli());
+        return cal;
+    }
+}

--- a/cms/src/test/java/org/onehippo/forge/resetpassword/frontend/UserIdValidatorTest.java
+++ b/cms/src/test/java/org/onehippo/forge/resetpassword/frontend/UserIdValidatorTest.java
@@ -1,0 +1,116 @@
+/*
+ *  Copyright 2024 Bloomreach Inc. (https://www.bloomreach.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.onehippo.forge.resetpassword.frontend;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UserIdValidatorTest {
+
+    // --- rejection of traversal vectors ---
+
+    @Test
+    void null_is_invalid() {
+        assertFalse(UserIdValidator.isValid(null));
+    }
+
+    @Test
+    void empty_string_is_invalid() {
+        assertFalse(UserIdValidator.isValid(""));
+    }
+
+    @Test
+    void single_character_is_invalid() {
+        assertFalse(UserIdValidator.isValid("a"));
+    }
+
+    @Test
+    void forward_slash_is_invalid() {
+        assertFalse(UserIdValidator.isValid("ad/min"));
+    }
+
+    @Test
+    void path_traversal_with_double_dot_is_invalid() {
+        assertFalse(UserIdValidator.isValid("../hippo:groups"));
+    }
+
+    @Test
+    void double_dot_without_slash_is_invalid() {
+        assertFalse(UserIdValidator.isValid("..admin"));
+    }
+
+    @Test
+    void leading_slash_is_invalid() {
+        assertFalse(UserIdValidator.isValid("/admin"));
+    }
+
+    @Test
+    void deep_traversal_is_invalid() {
+        assertFalse(UserIdValidator.isValid("../../../../jcr:system"));
+    }
+
+    @Test
+    void null_byte_is_invalid() {
+        assertFalse(UserIdValidator.isValid("admin\0extra"));
+    }
+
+    // --- characters the CMS legitimately allows ---
+
+    @Test
+    void simple_username_is_valid() {
+        assertTrue(UserIdValidator.isValid("admin"));
+    }
+
+    @Test
+    void minimum_two_character_username_is_valid() {
+        assertTrue(UserIdValidator.isValid("ab"));
+    }
+
+    @Test
+    void username_with_dots_dashes_underscores_is_valid() {
+        assertTrue(UserIdValidator.isValid("john.doe-123_test"));
+    }
+
+    @Test
+    void email_style_username_is_valid() {
+        assertTrue(UserIdValidator.isValid("john.doe@example.com"));
+    }
+
+    @Test
+    void email_with_plus_tag_is_valid() {
+        assertTrue(UserIdValidator.isValid("user+tag@company.com"));
+    }
+
+    @Test
+    void unicode_username_is_valid() {
+        assertTrue(UserIdValidator.isValid("André"));
+    }
+
+    @Test
+    void jcr_colon_without_slash_is_valid() {
+        // ':' is a JCR namespace separator but not a path separator;
+        // JCR itself will reject nodes with invalid namespaces, so we allow it here.
+        assertTrue(UserIdValidator.isValid("hippo:admin"));
+    }
+
+    @Test
+    void single_dot_is_valid() {
+        // a single dot is not a traversal sequence
+        assertTrue(UserIdValidator.isValid("a.b"));
+    }
+}

--- a/demo/essentials/pom.xml
+++ b/demo/essentials/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>org.bloomreach.forge.resetpassword</groupId>
       <artifactId>reset-password-essentials</artifactId>
-      <version>6.0.1-SNAPSHOT</version>
+      <version>${bloomreach.forge.reset-password.version}</version>
     </dependency>
     <dependency>
       <groupId>org.onehippo.cms7</groupId>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -65,7 +65,7 @@
 
     <development-module-deploy-dir>shared/lib</development-module-deploy-dir>
 
-    <bloomreach.forge.reset-password.version>6.0.1-SNAPSHOT</bloomreach.forge.reset-password.version>
+    <bloomreach.forge.reset-password.version>7.0.1-SNAPSHOT</bloomreach.forge.reset-password.version>
 
     <docker.postgres.bind.1>${project.basedir}/target/postgres-data:/var/lib/postgresql/data</docker.postgres.bind.1>
 


### PR DESCRIPTION
…token abuse

Prevent JCR path traversal by validating userId before path construction. Add per-username rate limiting to slow automated reset enumeration. Persist reset token before sending email; clear token before saving password. Remove token URL from debug logs; escape feedback panel output to prevent XSS. Fix "null null" display name bug and align demo version references to 7.0.1-SNAPSHOT.

(co-authored with Claude Code)