### PR TITLE
chore: FORGE-596 upgrade Reset Password plugin to BrXM v17

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,46 +28,47 @@ and therefore ignored by Git.
      <dependency>
         <groupId>org.bloomreach.forge.resetpassword</groupId>
         <artifactId>reset-password-essentials</artifactId>
-        <version>7.0.0</version>       
+        <version>8.0.0</version>       
      </dependency>
 ```
  
-add mail session JNDI resource to local context.xml, e.g.:
- 
-```
-    <Resource name="mail/Session" 
-      auth="Container" 
-      type="javax.mail.Session" 
-      mail.smtp.host="127.0.0.1"
-      mail.smtp.port= "2525"  
-      />
-```
+The demo project's `conf/context.xml` is pre-configured for [MailHog](https://github.com/mailhog/MailHog), a local SMTP server that captures outbound mail without delivering it.
 
-___
-Download  FakeSMTP from:
-
-[https://github.com/Nilhcem/FakeSMTP](https://github.com/Nilhcem/FakeSMTP)
-
-and run it as:
+Start MailHog via Docker:
 
 ```bash
-java -jar fakeSMTP-2.1-SNAPSHOT.jar -s  -p 2525 -a 127.0.0.1
+docker run -d -p 1025:1025 -p 8025:8025 --name mailhog mailhog/mailhog
 ```
-If you encounter issues on Mac, you can try to run it as:
+
+Or via Homebrew:
 
 ```bash
-java --add-exports java.desktop/com.apple.eawt=ALL-UNNAMED -jar fakeSMTP-2.1-SNAPSHOT.jar -s -p 2525 -a 127.0.0.1
+brew install mailhog
+MailHog
 ```
 
-You may also need to update FakeSMTP to use Java 7 instead of Java 6.
-___
+The demo `conf/context.xml` is already configured to use it:
+
+```xml
+<Resource name="mail/Session"
+  auth="Container"
+  type="jakarta.mail.Session"
+  mail.smtp.host="localhost"
+  mail.smtp.port="1025"
+/>
+```
+
+Captured emails are viewable at [http://localhost:8025](http://localhost:8025).
+
+---
+
 -> Go to CMS login page.
 
 -> Click on Forgot password, it will take you to the Reset Password page.
 
 -> Enter the username and click on Reset.
 
--> An email will be sent to the Fake SMTP Server with a link to reset the password.
+-> An email will be sent to MailHog with a link to reset the password. Open [http://localhost:8025](http://localhost:8025) to view it.
 
 -> Click on the link, it will take you to the Reset Password page, enter the new password and click on Reset.
 

--- a/bootstrap/configuration/pom.xml
+++ b/bootstrap/configuration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.resetpassword</groupId>
     <artifactId>resetpassword-bootstrap</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach Reset Password Bootstrap Configuration</name>

--- a/bootstrap/content/pom.xml
+++ b/bootstrap/content/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.resetpassword</groupId>
     <artifactId>resetpassword-bootstrap</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach Reset Password Bootstrap Content</name>

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.resetpassword</groupId>
     <artifactId>resetpassword</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach Reset Password Bootstrap</name>

--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.bloomreach.forge.resetpassword</groupId>
     <artifactId>resetpassword</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach Reset Password CMS</name>

--- a/demo/cms-dependencies/pom.xml
+++ b/demo/cms-dependencies/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>myproject-cms-dependencies</artifactId>
   <packaging>pom</packaging>

--- a/demo/cms/pom.xml
+++ b/demo/cms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>myproject-cms</artifactId>
   <packaging>war</packaging>

--- a/demo/conf/context.xml
+++ b/demo/conf/context.xml
@@ -23,6 +23,6 @@
               auth="Container"
               type="jakarta.mail.Session"
               mail.smtp.host="localhost"
-              mail.smtp.port="2525"
+              mail.smtp.port="1025"
     />
 </Context>

--- a/demo/essentials/pom.xml
+++ b/demo/essentials/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>myproject-essentials</artifactId>
   <packaging>war</packaging>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>org.bloomreach.forge.resetpassword</groupId>
       <artifactId>reset-password-essentials</artifactId>
-      <version>6.0.1-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.onehippo.cms7</groupId>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,14 +5,14 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>16.0.0</version>
+    <version>17.0.0</version>
   </parent>
 
   <name>My Project</name>
   <description>My Project</description>
   <groupId>org.example</groupId>
   <artifactId>myproject</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>8.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <!--
@@ -61,11 +61,11 @@
     <!--***START temporary override of versions*** -->
     <!-- ***END temporary override of versions*** -->
 
-    <essentials.version>16.0.0</essentials.version>
+    <essentials.version>17.0.0</essentials.version>
 
     <development-module-deploy-dir>shared/lib</development-module-deploy-dir>
 
-    <bloomreach.forge.reset-password.version>6.0.1-SNAPSHOT</bloomreach.forge.reset-password.version>
+    <bloomreach.forge.reset-password.version>8.0.0-SNAPSHOT</bloomreach.forge.reset-password.version>
 
     <docker.postgres.bind.1>${project.basedir}/target/postgres-data:/var/lib/postgresql/data</docker.postgres.bind.1>
 

--- a/demo/repository-data/application/pom.xml
+++ b/demo/repository-data/application/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject-repository-data</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>My Project Repository Data For Application</name>

--- a/demo/repository-data/application/src/main/resources/hcm-config/configuration/test.yaml
+++ b/demo/repository-data/application/src/main/resources/hcm-config/configuration/test.yaml
@@ -6,7 +6,8 @@ definitions:
       hipposys:email: test@bloomreach.com
       hipposys:firstname: Test
       hipposys:lastname: Test
-      hipposys:password: $SHA-256$OvL+tdvRRLo=$JwYtKl+uAMDNWXpH67//WEAZwRev2kNPKlvV9dYuT14=
-      hipposys:passwordlastmodified: 2020-05-28T16:26:21.736+02:00
+      hipposys:password: $SHA-256$U3rrJAcUf3E=$8D0z6yqi11btUn4KVP/1fUj73LphU/NzZ4zOsexrj2E=
+      hipposys:passwordlastmodified: 2026-05-28T11:44:32.415-05:00
       hipposys:securityprovider: internal
       jcr:mixinTypes: ['hippostd:relaxed']
+      hipposys:previouspasswords: [$SHA-256$OvL+tdvRRLo=$JwYtKl+uAMDNWXpH67//WEAZwRev2kNPKlvV9dYuT14=]

--- a/demo/repository-data/development/pom.xml
+++ b/demo/repository-data/development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject-repository-data</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>My Project Repository Data For Development</name>

--- a/demo/repository-data/pom.xml
+++ b/demo/repository-data/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>My Project Repository Data</name>

--- a/demo/repository-data/site-development/pom.xml
+++ b/demo/repository-data/site-development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject-repository-data</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>My Project Repository Data For Site Development</name>

--- a/demo/repository-data/site/pom.xml
+++ b/demo/repository-data/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject-repository-data</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>My Project Repository Data For Site</name>

--- a/demo/repository-data/webfiles/pom.xml
+++ b/demo/repository-data/webfiles/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject-repository-data</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>My Project Repository Data Web Files</name>

--- a/demo/site/components/pom.xml
+++ b/demo/site/components/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject-site</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>myproject-components</artifactId>
   <packaging>jar</packaging>

--- a/demo/site/pom.xml
+++ b/demo/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>myproject-site</artifactId>
   <packaging>pom</packaging>

--- a/demo/site/webapp/pom.xml
+++ b/demo/site/webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject-site</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>myproject-webapp</artifactId>
   <packaging>war</packaging>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.example</groupId>
       <artifactId>myproject-components</artifactId>
-      <version>7.0.1-SNAPSHOT</version>
+      <version>8.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.onehippo.cms7.hst.toolkit-resources.addon</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>16.0.0</version>
+    <version>17.0.0</version>
   </parent>
 
   <name>Bloomreach Reset Password</name>
   <description>Hippo Reset Password</description>
   <groupId>org.bloomreach.forge.resetpassword</groupId>
   <artifactId>resetpassword</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>8.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <url>https://github.com/bloomreach-forge/reset-password</url>
   <inceptionYear>2016</inceptionYear>
@@ -45,7 +45,7 @@
 
   <issueManagement>
     <system>Jira</system>
-    <url>https://issues.onehippo.com/browse/FORGE</url>
+    <url>https://bloomreach.atlassian.net/browse/FORGE</url>
   </issueManagement>
 
   <licenses>
@@ -135,7 +135,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven.plugin.compiler.version}</version>
         <configuration>
-          <release>17</release>
+          <release>21</release>
         </configuration>
       </plugin>
       <plugin>

--- a/reset-password-essentials/pom.xml
+++ b/reset-password-essentials/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.bloomreach.forge.resetpassword</groupId>
     <artifactId>resetpassword</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach Reset Password Essentials Plugin</name>

--- a/reset-password-essentials/src/main/java/org/onehippo/forge/essentials/resetpassword/instructions/AddFilterInstruction.java
+++ b/reset-password-essentials/src/main/java/org/onehippo/forge/essentials/resetpassword/instructions/AddFilterInstruction.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.onehippo.cms7.essentials.sdk.api.install.Instruction;
 import org.onehippo.cms7.essentials.sdk.api.model.Module;

--- a/reset-password-essentials/src/main/java/org/onehippo/forge/essentials/resetpassword/instructions/AddVersionsInstruction.java
+++ b/reset-password-essentials/src/main/java/org/onehippo/forge/essentials/resetpassword/instructions/AddVersionsInstruction.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.function.BiConsumer;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.model.Model;


### PR DESCRIPTION
Enables compatibility with BrXM v17 (JDK 21, Spring Boot 4). javax.inject migrated to jakarta.inject; commons-email2 pinned to available 2.0.0-M1 release; demo essentials version decoupled from hardcoded snapshot via \${project.version}.
Replace outdated FakeSMTP dev instructions with MailHog (Docker/Homebrew).

(co-authored with Claude Code)